### PR TITLE
Move letters from Upper/Lower into contraction operation

### DIFF
--- a/src/ricci.jl
+++ b/src/ricci.jl
@@ -7,8 +7,6 @@ import Base.adjoint
 export Upper, Lower
 export Sym, KrD, Zero
 
-export equivalent
-
 export flip
 
 export to_string
@@ -37,11 +35,19 @@ function same(_::Upper)
     return Upper()
 end
 
-function ==(left::LowerOrUpperIndex, right::LowerOrUpperIndex)
-    if typeof(left) == typeof(right)
-        return true
-    end
+function ==(left::Lower, right::Lower)
+    return true
+end
 
+function ==(left::Upper, right::Upper)
+    return true
+end
+
+function ==(left::Lower, right::Upper)
+    return false
+end
+
+function ==(left::Upper, right::Lower)
     return false
 end
 
@@ -75,16 +81,13 @@ function ==(left::Sym, right::Sym)
     return left.id == right.id && left.indices == right.indices
 end
 
-function equivalent(left::Sym, right::Sym)
-    return left.id == right.id && all(typeof.(left.indices) .== typeof.(right.indices))
-end
-
 struct KrD <: SymbolicValue
     indices::IndexSet
 
     function KrD(indices::LowerOrUpperIndex...)
         indices = LowerOrUpperIndex[i for i ∈ indices]
-        if isempty(eliminate_indices(indices))
+
+        if length(indices) < 2
             throw(DomainError(indices, "Indices $indices of δ are invalid"))
         end
 
@@ -110,8 +113,8 @@ function ==(left::Zero, right::Zero)
     return left.indices == right.indices
 end
 
-IndexPair = Tuple{Int64, Int64}
-Contractions = Vector{IndexPair}
+ContractingPair = Tuple{Int64, Int64}
+Contractions = Vector{ContractingPair}
 
 # TODO: Rename to contraction
 struct BinaryOperation{Op} <: SymbolicValue where Op
@@ -119,6 +122,8 @@ struct BinaryOperation{Op} <: SymbolicValue where Op
     arg2::SymbolicValue
     indices::Contractions
 end
+
+# TODO: Check BinaryOperation validity in constructor
 
 function ==(left::BinaryOperation{Op}, right::BinaryOperation{Op}) where Op
     same_args = left.arg1 == right.arg1 && left.arg2 == right.arg2
@@ -135,77 +140,45 @@ function ==(left::UnaryOperation, right::UnaryOperation)
     return left.arg == right.arg && left.op == right.op
 end
 
-function eliminate_indices(arg1, arg2, indices)
-    arg1_indices = Union{LowerOrUpperIndex, Nothing}[i for i ∈ get_free_indices(arg1)]
-    arg2_indices = Union{LowerOrUpperIndex, Nothing}[i for i ∈ get_free_indices(arg2)]
+function eliminate_indices(arg1::IndexSet, arg2::IndexSet, indices)
+    arg1 = Union{LowerOrUpperIndex, Nothing}[i for i ∈ arg1]
+    arg2 = Union{LowerOrUpperIndex, Nothing}[i for i ∈ arg2]
 
     for pair ∈ indices
-        if typeof(flip(arg1_indices[pair[1]])) == typeof(arg2_indices[pair[2]])
-            arg1_indices[pair[1]] = nothing
-            arg2_indices[pair[2]] = nothing
+        if typeof(flip(arg1[pair[1]])) == typeof(arg2[pair[2]])
+            arg1[pair[1]] = nothing
+            arg2[pair[2]] = nothing
         end
     end
 
-    arg1_remaining = filter(i -> !isnothing(i), arg1_indices)
-    arg2_remaining = filter(i -> !isnothing(i), arg2_indices)
+    remaining = LowerOrUpperIndex[]
 
-    @assert length(arg1_remaining) + length(arg2_remaining) < length(arg1_indices) + length(arg2_indices)
+    for i ∈ arg1
+        if !isnothing(i)
+            push!(remaining, i)
+        end
+    end
 
-    return [arg1_remaining; arg2_remaining]
+    for i ∈ arg2
+        if !isnothing(i)
+            push!(remaining, i)
+        end
+    end
+
+    @assert length(remaining) < length(arg1) + length(arg2)
+
+    return remaining
 end
 
-function eliminate_indices(arg::IndexSet)
-    available = Union{Nothing, Lower, Upper}[i for i ∈ arg]
+function eliminated_indices(arg1::IndexSet, arg2::IndexSet, indices)
+    arg1 = Union{LowerOrUpperIndex, Nothing}[i for i ∈ arg1]
+    arg2 = Union{LowerOrUpperIndex, Nothing}[i for i ∈ arg2]
 
-    for i ∈ eachindex(available)
-        if isnothing(available[i])
-            continue
-        end
+    eliminated = Contractions()
 
-        for j ∈ eachindex(available)
-            if isnothing(available[j])
-                continue
-            end
-
-            if flip(available[j]) == available[i]
-                available[i] = nothing
-                available[j] = nothing
-            end
-        end
-    end
-
-    filtered = LowerOrUpperIndex[]
-
-    for e ∈ available
-        if !isnothing(e)
-            push!(filtered, e)
-        end
-    end
-
-    return filtered
-end
-
-function eliminated_indices(arg::IndexSet)
-    available = Union{Nothing, Lower, Upper}[i for i ∈ arg]
-    eliminated = LowerOrUpperIndex[]
-
-    for i ∈ eachindex(available)
-        if isnothing(available[i])
-            continue
-        end
-
-        for j ∈ eachindex(available)
-            if isnothing(available[j])
-                continue
-            end
-
-            if flip(available[j]) == available[i]
-                push!(eliminated, available[i])
-                push!(eliminated, available[j])
-
-                available[i] = nothing
-                available[j] = nothing
-            end
+    for pair ∈ indices
+        if typeof(flip(arg1[pair[1]])) == typeof(arg2[pair[2]])
+            push!(eliminated, pair)
         end
     end
 
@@ -217,219 +190,37 @@ function get_free_indices(arg::Union{Sym, KrD, Zero})
 end
 
 function get_free_indices(arg::UnaryOperation)
-    eliminate_indices([get_free_indices(arg.arg); get_free_indices(arg.op)])
+    @assert false "Not implemented"
 end
 
 function get_free_indices(arg::BinaryOperation{*})
-    eliminate_indices([get_free_indices(arg.arg1); get_free_indices(arg.arg2)])
+    eliminate_indices(get_free_indices(arg.arg1), get_free_indices(arg.arg2), arg.indices)
 end
 
-function are_indices_unique(indices::IndexSet)
-    return length(unique(indices)) == length(indices)
-end
-
-function can_contract(arg1, arg2, index)
+function can_contract(arg1, arg2, indices::Contractions)
     arg1_indices = get_free_indices(arg1)
     arg2_indices = get_free_indices(arg2)
 
-    for i ∈ arg1_indices
-        if i.letter == index
-            for j ∈ arg2_indices
-                if flip(i) == j
-                    return true
-                end
-            end
+    for pair ∈ indices
+        if typeof(arg1_indices[pair[1]]) == typeof(arg2_indices[pair[2]])
+            return false
         end
     end
 
-    return false
-end
-
-function can_contract(arg1::KrD, arg2)
-    return can_contract_weak(arg2, arg1)
-end
-
-function can_contract(arg1, arg2::KrD)
-    return can_contract_weak(arg1, arg2)
-end
-
-function can_contract(arg1::KrD, arg2::Sym)
-    return can_contract_weak(arg2, arg1)
-end
-
-function can_contract(arg1::Sym, arg2::KrD)
-    return can_contract_weak(arg1, arg2)
-end
-
-function can_contract(arg1::KrD, arg2::KrD)
-    return can_contract_weak(arg1, arg2) || can_contract_weak(arg2, arg1)
-end
-
-function can_contract_weak(arg1, arg2::KrD)
-    arg1_indices = get_free_indices(arg1)
-    arg2_indices = get_free_indices(arg2)
-
-    # If there is a matching index pair then the contraction is unambigous.
-    # Duplicate pairs such that several indices in arg2 matches one index in
-    # arg1 are allowed.
-
-    pairs = Dict{Letter, Int64}()
-
-    for j ∈ arg2_indices
-        pairs_in_sweep = Dict{Letter, Int64}()
-
-        for i ∈ arg1_indices
-            if flip(i) == j
-                if haskey(pairs_in_sweep, i.letter)
-                    return false
-                else
-                    pairs_in_sweep[i.letter] = 1
-
-                    if haskey(pairs, i.letter)
-                        pairs[i.letter] += 1
-                    else
-                        pairs[i.letter] = 0
-                    end
-                end
-            end
-        end
-    end
-
-    if length(pairs) == 1
-        return true
-    end
-
-    return false
-end
-
-function can_contract(arg1::Sym, arg2::Sym)
-    return can_contract_strong(arg2, arg1)
-end
-
-function can_contract(arg1, arg2::Sym)
-    return can_contract_strong(arg2, arg1)
-end
-
-function can_contract(arg1::Sym, arg2)
-    return can_contract_strong(arg1, arg2)
-end
-
-function can_contract_strong(arg1, arg2)
-    arg1_indices = get_free_indices(arg1)
-    arg2_indices = get_free_indices(arg2)
-
-    # If there is exactly one matching index pair then the contraction is unambigous.
-    pairs = Dict{Letter, Int64}()
-
-    for i ∈ arg1_indices
-        for j ∈ arg2_indices
-            if flip(i) == j
-                if haskey(pairs, i.letter)
-                    pairs[i.letter] += 1
-                else
-                    pairs[i.letter] = 1
-                end
-            end
-        end
-    end
-
-    if length(pairs) == 1 && first(values(pairs)) == 1
-        return true
-    end
-
-    return false
+    return true
 end
 
 function is_valid_multiplication(arg1, arg2)
     arg1_indices = get_free_indices(arg1)
     arg2_indices = get_free_indices(arg2)
 
-    if (length(arg1_indices) == 2 && length(arg2_indices) == 1) || (length(arg1_indices) == 1 && length(arg2_indices) == 2)
+    if length(arg1_indices) <= 2 && length(arg2_indices) <= 2
         if typeof(arg1_indices[end]) == Lower && typeof(arg2_indices[1]) == Upper
             return true
         end
     end
 
     return false
-end
-
-function is_contraction_unambigous(arg1, arg2)
-    arg1_indices = get_free_indices(arg1)
-    arg2_indices = get_free_indices(arg2)
-
-    # Check that indices are unique.
-    if !are_indices_unique(arg1_indices) || !are_indices_unique(arg2_indices)
-        return false
-    end
-
-    # Check that there are no contractions within the arguments.
-    if !isempty(eliminated_indices(arg1_indices)) || !isempty(eliminated_indices(arg2_indices))
-        return false
-    end
-
-    # Otherwise, if there is exactly one matching index pair then the contraction is unambigous.
-    pairs = Dict{Letter, Int64}()
-
-    for i ∈ arg1_indices
-        for j ∈ arg2_indices
-            if flip(i) == j
-                if haskey(pairs, i.letter)
-                    pairs[i.letter] += 1
-                else
-                    pairs[i.letter] = 1
-                end
-            end
-        end
-    end
-
-    if length(pairs) == 1 && first(values(pairs)) == 1
-        return true
-    end
-
-    # Otherwise, if there is an unambigous Upper/Lower pair then the
-    # contraction can be done with updated indices.
-    # We don't updated the indices here.
-    if length(arg1_indices) == 1 || length(arg2_indices) == 1
-        for i ∈ arg1_indices
-            for j ∈ arg2_indices
-                if typeof(flip(i)) == typeof(j)
-                    return true
-                end
-            end
-        end
-    end
-
-    return false
-end
-
-# If any other except arg1.indices[end] and arg2.indices[1] match
-# then the input does not correspond to valid standard notation.
-# TODO: Rename - include "multiplication" or "contraction" in the name.
-function is_valid_standard_notation(arg1, arg2)
-    arg1_indices = get_free_indices(arg1)
-    arg2_indices = get_free_indices(arg2)
-
-    if length(arg1_indices) == 1
-        arg1_indices = [arg1_indices; arg1_indices]
-    end
-
-    if length(arg2_indices) == 1
-        arg2_indices = [arg2_indices; arg2_indices]
-    end
-
-    for i ∈ arg1_indices[1:end-1]
-        for j ∈ arg2_indices[2:end]
-            if i.letter == j.letter
-                return false
-            end
-        end
-    end
-
-    if flip(arg1.indices[end]) != arg2.indices[1]
-        return false
-    end
-
-    return true
 end
 
 function *(arg1, arg2)
@@ -450,22 +241,6 @@ end
 
 function +(arg1::SymbolicValue, arg2::SymbolicValue)
     BinaryOperation{+}(arg1, arg2)
-end
-
-function update_index(arg, from::LowerOrUpperIndex, to::LowerOrUpperIndex)
-    indices = get_free_indices(arg)
-
-    if from == to
-        return arg
-    end
-
-    @assert from ∈ indices
-
-    if typeof(from) == typeof(flip(to))
-        throw(DomainError((from, to), "requested a transpose which isn't allowed"))
-    end
-
-    return BinaryOperation{*}(arg, KrD(flip(from), to))
 end
 
 function adjoint(arg::UnaryOperation)
@@ -498,7 +273,7 @@ function adjoint(arg::Union{Sym, KrD, Zero})
     if length(ids) == 1
         BinaryOperation{*}(arg, KrD(flip(ids[1]), flip(ids[1])), [(1, 1)])
     elseif length(ids) == 2
-        BinaryOperation{*}(BinaryOperation{*}(arg, KrD(flip(ids[2]), flip(ids[2]))), KrD(flip(ids[1]), flip(ids[1])))
+        BinaryOperation{*}(BinaryOperation{*}(arg, KrD(flip(ids[2]), flip(ids[2])), [(2, 1)]), KrD(flip(ids[1]), flip(ids[1])), [(1, 1)])
     else
         throw(DomainError("Ambgious transpose"))
     end
@@ -529,15 +304,11 @@ function script(_::Upper, letter::Letter)
 end
 
 function to_string(arg::Sym)
-    scripts = [script(i) for i ∈ arg.indices]
-
-    arg.id * join(scripts)
+    arg.id
 end
 
 function to_string(arg::KrD)
-    scripts = [script(i) for i ∈ arg.indices]
-
-    "δ" * join(scripts)
+    "δ"
 end
 
 function to_string(arg::Real)
@@ -558,16 +329,19 @@ function to_string(arg::BinaryOperation{*})
     to_string(arg.arg1, arg.arg2, arg.indices)
 end
 
-function to_string(arg1::Sym, arg2::Sym, contractions::Contractions)
+function to_string(arg1, arg2, contractions::Contractions)
     arg1_contracting_indices = [p[1] for p ∈ contractions]
     arg2_contracting_indices = [p[2] for p ∈ contractions]
 
     next_free_index = length(contractions) + 1
     next_dummy_index = 1
 
-    out = arg1.id
+    out = to_string(arg1)
+    if typeof(arg1) != Sym && typeof(arg1) != KrD
+        out = "(" * out * ")"
+    end
 
-    for (i,ul) ∈ enumerate(arg1.indices)
+    for (i,ul) ∈ enumerate(get_free_indices(arg1))
         if i ∈ arg1_contracting_indices
             out *= script(ul, next_dummy_index)
             next_dummy_index += 1
@@ -577,7 +351,7 @@ function to_string(arg1::Sym, arg2::Sym, contractions::Contractions)
         end
     end
 
-    out *= arg2.id
+    out *= to_string(arg2)
     next_dummy_index = 1
 
     for (i,ul) ∈ enumerate(arg2.indices)

--- a/test/ForwardTest.jl
+++ b/test/ForwardTest.jl
@@ -4,8 +4,8 @@ using Test
 MD = MatrixDiff
 
 @testset "evaluate Sym" begin
-    A = Sym("A", Upper(1), Lower(2))
-    x = Sym("x", Upper(3))
+    A = Sym("A", Upper(), Lower())
+    x = Sym("x", Upper())
     z = Sym("z")
 
     @test evaluate(A) == A
@@ -13,152 +13,134 @@ MD = MatrixDiff
     @test evaluate(z) == z
 end
 
-@testset "evaluate KrD simple" begin
-    A = Sym("A", Upper(1), Lower(2))
-    x = Sym("x", Upper(1))
-    z = Sym("z")
-
-    d1 = KrD(Lower(1), Upper(3))
-    d2 = KrD(Upper(2), Lower(3))
-
-    @test evaluate(MD.UnaryOperation(d1, A)) == Sym("A", Upper(3), Lower(2))
-    @test evaluate(MD.UnaryOperation(d1, x)) == Sym("x", Upper(3))
-    @test evaluate(MD.UnaryOperation(d1, z)) == MD.UnaryOperation(d1, z)
-    @test evaluate(MD.UnaryOperation(d2, A)) == Sym("A", Upper(1), Lower(3))
-end
-
-@testset "evaluate transpose simple" begin
-    A = Sym("A", Upper(1), Lower(2))
-    x = Sym("x", Upper(1))
-    z = Sym("z")
-
-    # @test evaluate(A') == Sym("A", Upper(2), Lower(1)) # Not implemented
-    @test evaluate(x') == Sym("x", Lower(1))
-    # @test evaluate(z') == Sym("z") # Not implemented
-end
-
-@testset "evaluate UnaryOperation vector-KrD" begin
-    x = Sym("x", Upper(2))
-    d1 = KrD(Lower(2), Upper(3))
-    d2 = KrD(Lower(2), Lower(2))
-
-    @test evaluate(MD.UnaryOperation(d1, x)) == Sym("x", Upper(3))
-    @test evaluate(MD.UnaryOperation(d2, x)) == Sym("x", Lower(2))
-end
-
-@testset "evaluate UnaryOperation matrix-KrD" begin
-    A = Sym("A", Upper(2), Lower(4))
-    d1 = KrD(Lower(2), Upper(3))
-    d2 = KrD(Lower(2), Lower(2))
-
-    @test evaluate(MD.UnaryOperation(d1, A)) == Sym("A", Upper(3), Lower(4))
-    @test evaluate(MD.UnaryOperation(d2, A)) == Sym("A", Lower(2), Lower(4))
-end
-
-@testset "evaluate UnaryOperation KrD-KrD" begin
-    d1 = KrD(Upper(1), Lower(2))
-    d2 = KrD(Upper(2), Lower(3))
-
-    @test evaluate(MD.UnaryOperation(d1, d2)) == KrD(Upper(1), Lower(3))
-    @test evaluate(MD.UnaryOperation(d2, d1)) == KrD(Upper(1), Lower(3))
-end
-
 @testset "evaluate BinaryOperation vector-KrD" begin
-    x = Sym("x", Upper(2))
-    d1 = KrD(Lower(2), Upper(3))
-    d2 = KrD(Lower(2), Lower(2))
+    x = Sym("x", Upper())
+    d1 = KrD(Lower(), Upper())
+    d2 = KrD(Lower(), Lower())
 
-    @test evaluate(MD.BinaryOperation{*}(d1, x)) == Sym("x", Upper(3))
-    @test evaluate(MD.BinaryOperation{*}(x, d1)) == Sym("x", Upper(3))
-    @test evaluate(MD.BinaryOperation{*}(d2, x)) == Sym("x", Lower(2))
-    @test evaluate(MD.BinaryOperation{*}(x, d2)) == Sym("x", Lower(2))
+    @test evaluate(MD.BinaryOperation{*}(d1, x, [(1, 1)])) == Sym("x", Upper())
+    @test evaluate(MD.BinaryOperation{*}(x, d1, [(1, 1)])) == Sym("x", Upper())
+    @test evaluate(MD.BinaryOperation{*}(d2, x, [(1, 1)])) == Sym("x", Lower())
+    @test evaluate(MD.BinaryOperation{*}(x, d2, [(1, 1)])) == Sym("x", Lower())
+    @test evaluate(MD.BinaryOperation{*}(d2, x, [(2, 1)])) == Sym("x", Lower())
+    @test evaluate(MD.BinaryOperation{*}(x, d2, [(1, 2)])) == Sym("x", Lower())
+
 end
 
 @testset "evaluate BinaryOperation matrix-KrD" begin
-    A = Sym("A", Upper(2), Lower(4))
-    d1 = KrD(Lower(2), Upper(3))
-    d2 = KrD(Lower(2), Lower(2))
+    A = Sym("A", Upper(), Lower())
+    d1 = KrD(Upper(), Upper())
+    d2 = KrD(Lower(), Lower())
 
-    @test evaluate(MD.BinaryOperation{*}(d1, A)) == Sym("A", Upper(3), Lower(4))
-    @test evaluate(MD.BinaryOperation{*}(A, d1)) == Sym("A", Upper(3), Lower(4))
-    @test evaluate(MD.BinaryOperation{*}(d2, A)) == Sym("A", Lower(2), Lower(4))
-    @test evaluate(MD.BinaryOperation{*}(A, d2)) == Sym("A", Lower(2), Lower(4))
+    @test evaluate(MD.BinaryOperation{*}(d1, A, [(2, 2)])) == Sym("A", Upper(), Upper())
+    @test evaluate(MD.BinaryOperation{*}(d2, A, [(1, 1)])) == Sym("A", Lower(), Lower())
 end
 
 @testset "evaluate BinaryOperation KrD-KrD" begin
-    d1 = KrD(Upper(1), Lower(2))
-    d2 = KrD(Upper(2), Lower(3))
+    d1 = KrD(Upper(), Lower())
+    d2 = KrD(Upper(), Lower())
 
-    @test evaluate(MD.BinaryOperation{*}(d1, d2)) == KrD(Upper(1), Lower(3))
-    @test evaluate(MD.BinaryOperation{*}(d2, d1)) == KrD(Upper(1), Lower(3))
+    @test evaluate(MD.BinaryOperation{*}(d1, d2, [(2, 1)])) == KrD(Upper(), Lower())
+    @test evaluate(MD.BinaryOperation{*}(d2, d1, [(2, 1)])) == KrD(Upper(), Lower())
 end
 
-@testset "evaluate BinaryOperation*" begin
-    A = Sym("A", Upper(1), Lower(2))
-    x = Sym("x", Upper(2))
-    y = Sym("y", Upper(3))
+@testset "evaluate BinaryOperation matrix-KrD" begin
+    A = Sym("A", Upper(), Lower())
+    d1 = KrD(Lower(), Upper())
+    d2 = KrD(Lower(), Lower())
 
-    @test evaluate(MD.BinaryOperation{*}(A, x)) == MD.BinaryOperation{*}(A, x)
-    @test evaluate(MD.BinaryOperation{*}(A, y)) == MD.BinaryOperation{*}(A, y)
+    @test evaluate(MD.BinaryOperation{*}(d1, A, [(1, 1)])) == Sym("A", Upper(), Lower())
+    @test evaluate(MD.BinaryOperation{*}(A, d1, [(1, 1)])) == Sym("A", Upper(), Lower())
+    @test evaluate(MD.BinaryOperation{*}(d2, A, [(1, 1)])) == Sym("A", Lower(), Lower())
+    @test evaluate(MD.BinaryOperation{*}(d2, A, [(2, 1)])) == Sym("A", Lower(), Lower())
+    @test evaluate(MD.BinaryOperation{*}(A, d2, [(1, 1)])) == Sym("A", Lower(), Lower())
+    @test evaluate(MD.BinaryOperation{*}(A, d2, [(1, 2)])) == Sym("A", Lower(), Lower())
+end
+
+@testset "evaluate BinaryOperation KrD-KrD" begin
+    d1 = KrD(Upper(), Lower())
+    d2 = KrD(Upper(), Lower())
+
+    @test evaluate(MD.BinaryOperation{*}(d1, d2, [(1, 2)])) == KrD(Upper(), Lower())
+    @test evaluate(MD.BinaryOperation{*}(d2, d1, [(2, 1)])) == KrD(Upper(), Lower())
+end
+
+@testset "evaluate BinaryOperation matrix-vector" begin
+    A = Sym("A", Upper(), Lower())
+    x = Sym("x", Upper())
+    y = Sym("y", Lower())
+
+    @test evaluate(MD.BinaryOperation{*}(A, x, [(2, 1)])) == MD.BinaryOperation{*}(A, x, [(2, 1)])
+    @test evaluate(MD.BinaryOperation{*}(y, A, [(1, 1)])) == MD.BinaryOperation{*}(y, A, [(1, 1)])
+end
+
+@testset "evaluate transpose" begin
+    A = Sym("A", Upper(), Lower())
+    x = Sym("x", Upper())
+    z = Sym("z")
+
+    @test evaluate(A') == Sym("A", Lower(), Upper())
+    @test evaluate(x') == Sym("x", Lower())
+    # @test evaluate(z') == Sym("z") # Not implemented
 end
 
 @testset "diff Sym" begin
-    x = Sym("x", Upper(2))
-    y = Sym("y", Upper(3))
-    A = Sym("A", Upper(4), Lower(5))
+    x = Sym("x", Upper())
+    y = Sym("y", Upper())
+    A = Sym("A", Upper(), Lower())
 
-    @test MD.diff(x, x) == KrD(Upper(2), Lower(3))
-    @test MD.diff(y, x) == Zero(Upper(3), Lower(4))
-    @test MD.diff(A, x) == Zero(Upper(4), Lower(5), Lower(6))
+    @test MD.diff(x, x) == KrD(Upper(), Lower())
+    @test MD.diff(y, x) == Zero(Upper(), Lower())
+    @test MD.diff(A, x) == Zero(Upper(), Lower(), Lower())
 end
 
 @testset "diff KrD" begin
-    x = Sym("x", Upper(2))
-    y = Sym("y", Upper(3))
-    A = Sym("A", Upper(4), Lower(5))
+    x = Sym("x", Upper())
+    y = Sym("y", Upper())
+    A = Sym("A", Upper(), Lower())
 
-    @test MD.diff(x, x) == KrD(Upper(2), Lower(3))
-    @test MD.diff(y, x) == Zero(Upper(3), Lower(4))
-    @test MD.diff(A, x) == Zero(Upper(4), Lower(5), Lower(6))
+    @test MD.diff(x, x) == KrD(Upper(), Lower())
+    @test MD.diff(y, x) == Zero(Upper(), Lower())
+    @test MD.diff(A, x) == Zero(Upper(), Lower(), Lower())
 end
 
 @testset "diff UnaryOperation" begin
-    x = Sym("x", Upper(2))
+    x = Sym("x", Upper())
 
-    op = MD.UnaryOperation(KrD(Lower(2)), x)
+    op = MD.UnaryOperation(KrD(Lower(), Lower()), x)
 
-    @test MD.diff(op, x) == MD.UnaryOperation(KrD(Lower(2)), KrD(Upper(2), Lower(3)))
+    @test MD.diff(op, x) == MD.UnaryOperation(KrD(Lower(), Lower()), KrD(Upper(), Lower()))
 end
 
-@testset "diff UnaryOperation{*}" begin
-    x = Sym("x", Upper(2))
-    y = Sym("y", Lower(2))
+@testset "diff BinaryOperation{*}" begin
+    x = Sym("x", Upper())
+    y = Sym("y", Lower())
 
-    op = MD.BinaryOperation{*}(x, y)
+    op = MD.BinaryOperation{*}(x, y, [(1, 1)])
 
     D = MD.diff(op, x)
 
     @test typeof(D) == MD.BinaryOperation{+}
-    @test D.arg1 == MD.BinaryOperation{*}(x, Zero(Lower(2), Lower(3)))
-    @test D.arg2 == MD.BinaryOperation{*}(KrD(Upper(2), Lower(3)), y)
+    @test D.arg1 == MD.BinaryOperation{*}(x, Zero(Lower(), Lower()), [(1, 1)])
+    @test D.arg2 == MD.BinaryOperation{*}(KrD(Upper(), Lower()), y, [(1, 1)])
 end
 
-@testset "diff UnaryOperation{+}" begin
-    x = Sym("x", Upper(2))
-    y = Sym("y", Upper(2))
+@testset "diff BinaryOperation{+}" begin
+    x = Sym("x", Upper())
+    y = Sym("y", Upper())
 
-    op = MD.BinaryOperation{+}(x, y)
+    op = MD.BinaryOperation{+}(x, y, [])
 
     D = MD.diff(op, x)
 
-    @test D == MD.BinaryOperation{+}(KrD(Upper(2), Lower(3)), Zero(Upper(2), Lower(3)))
+    @test D == MD.BinaryOperation{+}(KrD(Upper(), Lower()), Zero(Upper(), Lower()), [])
 end
 
 @testset "Differentiate Ax" begin
-    A = Sym("A", Upper(1), Lower(2))
-    x = Sym("x", Upper(3))
+    A = Sym("A", Upper(), Lower())
+    x = Sym("x", Upper())
 
     e = A * x
 
-    @test equivalent(D(e, x), A)
+    @test D(e, x) == A
 end

--- a/test/RicciTest.jl
+++ b/test/RicciTest.jl
@@ -3,60 +3,74 @@ using Test
 
 MD = MatrixDiff
 
-@testset "Sym constructor throws on invalid input" begin
-    @test_throws DomainError Sym("A", Upper(2), Lower(2))
-    @test_throws DomainError Sym("A", Lower(2), Lower(2))
+@testset "Sym constructor creates a valid Sym" begin
+    A = Sym("A", Upper(), Lower())
+    @test A.id == "A"
+    @test A.indices == [Upper(); Lower()]
 
-    A = Sym("A", Upper(1), Lower(2))
-    B = Sym("B", Lower(1), Lower(2))
-    x = Sym("x", Upper(1))
-    y = Sym("y", Lower(1))
+    B = Sym("B", Lower(), Lower())
+    @test B.id == "B"
+    @test B.indices == [Lower(); Lower()]
+
+    x = Sym("x", Upper())
+    @test x.id == "x"
+    @test x.indices == [Upper()]
+
+    y = Sym("y", Lower())
+    @test y.id == "y"
+    @test y.indices == [Lower()]
+
     z = Sym("z")
+    @test z.id == "z"
+    @test isempty(z.indices)
 end
 
 @testset "index equality operator" begin
-    left = Lower(3)
-    right = Lower(3)
+    left = Lower()
+    right = Lower()
     @test left == right
-    @test left == Lower(3)
-    @test left != Upper(3)
-    @test left != Lower(1)
+    @test left == Lower()
+    @test left != Upper()
 end
 
 @testset "KrD constructor throws on invalid input" begin
-    @test_throws DomainError KrD(Upper(2), Lower(2))
+    @test_throws DomainError KrD(Upper())
+    @test_throws DomainError KrD()
+end
+
+@testset "KrD constructor creates a valid KrD" begin
+    d = KrD(Upper(), Upper())
+    @test d.indices == [Upper(); Upper()]
+
+    d2 = KrD(Upper(), Lower(), Upper())
+    @test d2.indices == [Upper(); Lower(); Upper()]
 end
 
 @testset "KrD equality operator" begin
-    left = KrD(Upper(1), Lower(2))
-    @test KrD(Upper(1), Lower(2)) == KrD(Upper(1), Lower(2))
-    @test !(KrD(Upper(1), Lower(2)) === KrD(Upper(1), Lower(2)))
-    @test left == KrD(Upper(1), Lower(2))
-    @test left != KrD(Upper(1), Upper(2))
-    @test left != KrD(Lower(1), Lower(2))
-    @test left != KrD(Upper(3), Lower(2))
-    @test left != KrD(Upper(1), Lower(3))
-    @test left != KrD(Upper(1))
-    @test left != KrD(Upper(1), Lower(2), Lower(3))
+    left = KrD(Upper(), Lower())
+    @test KrD(Upper(), Lower()) == KrD(Upper(), Lower())
+    @test !(KrD(Upper(), Lower()) === KrD(Upper(), Lower()))
+    @test left == KrD(Upper(), Lower())
+    @test left != KrD(Upper(), Upper())
+    @test left != KrD(Lower(), Lower())
+    @test left != KrD(Upper(), Lower(), Lower())
 end
 
 @testset "Zero equality operator" begin
-    left = Zero(Upper(1), Lower(2))
-    @test Zero(Upper(1), Lower(2)) == Zero(Upper(1), Lower(2))
-    @test !(Zero(Upper(1), Lower(2)) === Zero(Upper(1), Lower(2)))
-    @test left == Zero(Upper(1), Lower(2))
-    @test left != Zero(Upper(1), Upper(2))
-    @test left != Zero(Lower(1), Lower(2))
-    @test left != Zero(Upper(3), Lower(2))
-    @test left != Zero(Upper(1), Lower(3))
-    @test left != Zero(Upper(1))
-    @test left != Zero(Upper(1), Lower(2), Lower(3))
+    left = Zero(Upper(), Lower())
+    @test Zero(Upper(), Lower()) == Zero(Upper(), Lower())
+    @test !(Zero(Upper(), Lower()) === Zero(Upper(), Lower()))
+    @test left == Zero(Upper(), Lower())
+    @test left != Zero(Upper(), Upper())
+    @test left != Zero(Lower(), Lower())
+    @test left != Zero(Upper())
+    @test left != Zero(Upper(), Lower(), Lower())
     @test left != Zero()
 end
 
 @testset "UnaryOperation equality operator" begin
-    a = KrD(Upper(1), Upper(1))
-    b = Sym("b", Lower(1))
+    a = KrD(Upper(), Upper())
+    b = Sym("b", Lower())
 
     left = MD.UnaryOperation(a, b)
 
@@ -66,242 +80,128 @@ end
 end
 
 @testset "BinaryOperation equality operator" begin
-    a = Sym("a", Upper(1))
-    b = Sym("b", Lower(1))
+    a = Sym("a", Upper())
+    b = Sym("b", Lower())
 
-    left = MD.BinaryOperation{*}(a, b)
+    left = MD.BinaryOperation{*}(a, b, [(1, 1)])
 
-    @test MD.BinaryOperation{*}(a, b) == MD.BinaryOperation{*}(a, b)
-    @test left == MD.BinaryOperation{*}(a, b)
-    @test left == MD.BinaryOperation{*}(b, a)
-    @test left != MD.BinaryOperation{+}(a, b)
+    @test MD.BinaryOperation{*}(a, b, [(1, 1)]) == MD.BinaryOperation{*}(a, b, [(1, 1)])
+    @test left == MD.BinaryOperation{*}(a, b, [(1, 1)])
+    @test left == MD.BinaryOperation{*}(b, a, [(1, 1)])
+    @test left != MD.BinaryOperation{+}(a, b, [(1, 2)])
 end
 
 @testset "index hash function" begin
-    @test hash(Lower(3)) == hash(Lower(3))
-    @test hash(Lower(3)) != hash(Lower(1))
-    @test hash(Lower(1)) != hash(Lower(3))
-    @test hash(Upper(3)) != hash(Lower(3))
+    @test hash(Lower()) == hash(Lower())
+    @test hash(Upper()) != hash(Lower())
 end
 
 @testset "flip" begin
-    @test flip(Lower(3)) == Upper(3)
-    @test flip(Upper(3)) == Lower(3)
+    @test flip(Lower()) == Upper()
+    @test flip(Upper()) == Lower()
 end
 
 @testset "eliminate_indices removes correct indices" begin
     IdxUnion = MD.LowerOrUpperIndex
 
-    indices = IdxUnion[Lower(9); Upper(9); Upper(3); Lower(2); Lower(1); Lower(3); Lower(2); Upper(3); Upper(9); Lower(9)]
+    arg1 = IdxUnion[Upper(); Lower(); Lower()]
+    arg2 = IdxUnion[Upper(); Lower(); Lower()]
+    contractions = [(2, 1)]
 
-    output = MD.eliminate_indices(indices)
+    output = MD.eliminate_indices(arg1, arg2, contractions)
 
-    @test output == [Lower(2); Lower(1); Lower(2); Upper(3)]
-    @test MD.eliminate_indices(IdxUnion[]) == IdxUnion[]
+    @test output == [Upper(); Lower(); Lower(); Lower()]
 end
 
 @testset "eliminated_indices retains correct indices" begin
     IdxUnion = MD.LowerOrUpperIndex
 
-    indices = IdxUnion[Lower(9); Upper(9); Upper(3); Lower(2); Lower(1); Lower(3); Lower(2); Upper(3); Upper(9); Lower(9)]
+    arg1 = IdxUnion[Upper(); Lower(); Lower()]
+    arg2 = IdxUnion[Upper(); Lower(); Lower()]
+    contractions = [(2, 1)]
 
-    output = MD.eliminated_indices(indices)
+    output = MD.eliminated_indices(arg1, arg2, contractions)
 
-    @test output == IdxUnion[Lower(9); Upper(9); Upper(3); Lower(3); Upper(9); Lower(9)]
-    @test MD.eliminated_indices(IdxUnion[]) == IdxUnion[]
+    @test output == [(2, 1)]
 end
 
-@testset "get_free_indices with Sym-Sym and one matching pair" begin
-    xt = Sym("x", Lower(1)) # row vector
-    A = Sym("A", Upper(1), Lower(2))
+@testset "get_free_indices with Sym-Sym" begin
+    xt = Sym("x", Lower()) # row vector
+    A = Sym("A", Upper(), Lower())
 
-    op1 = MD.BinaryOperation{*}(xt, A)
-    op2 = MD.BinaryOperation{*}(A, xt)
+    op1 = MD.BinaryOperation{*}(xt, A, [(1, 1)])
+    op2 = MD.BinaryOperation{*}(A, xt, [(1, 1)]) # not valid standard notation
 
-    @test MD.get_free_indices(op1) == [Lower(2)]
-    @test MD.get_free_indices(op2) == [Lower(2)]
+    @test MD.get_free_indices(op1) == [Lower()]
+    @test MD.get_free_indices(op2) == [Lower()]
 end
 
-@testset "get_free_indices with Sym-KrD and one matching pair" begin
-    x = Sym("x", Upper(1))
-    δ = KrD(Lower(1), Lower(2))
+@testset "get_free_indices with Sym-KrD" begin
+    x = Sym("x", Upper())
+    δ = KrD(Lower(), Lower())
 
-    op1 = MD.BinaryOperation{*}(x, δ)
-    op2 = MD.BinaryOperation{*}(δ, x)
+    op1 = MD.BinaryOperation{*}(x, δ, [(1, 1)])
+    op2 = MD.BinaryOperation{*}(δ, x, [(1, 1)])
 
-    @test MD.get_free_indices(op1) == [Lower(2)]
-    @test MD.get_free_indices(op2) == [Lower(2)]
+    @test MD.get_free_indices(op1) == [Lower()]
+    @test MD.get_free_indices(op2) == [Lower()]
 end
 
-@testset "get_free_indices with Sym-KrD and two matching pairs" begin
-    x = Sym("x", Upper(1))
-    δ = KrD(Lower(1), Lower(1))
+@testset "is_valid_multiplication succeeds with valid matrix-vector input" begin
+    A = Sym("A", Upper(), Lower())
+    x = Sym("x", Upper())
+    y = Sym("y", Lower())
 
-    op1 = MD.BinaryOperation{*}(x, δ)
-    op2 = MD.BinaryOperation{*}(δ, x)
-
-    @test MD.get_free_indices(op1) == [Lower(1)]
-    @test MD.get_free_indices(op2) == [Lower(1)]
+    # TODO: add more tests here
+    @test MD.is_valid_multiplication(A, x)
+    @test MD.is_valid_multiplication(y, A)
 end
 
-@testset "get_free_indices with scalar Sym-KrD" begin
-    x = Sym("x")
-    δ = KrD(Lower(1), Lower(1))
+@testset "is_valid_multiplication fails with invalid matrix-vector input" begin
+    A = Sym("A", Upper(), Lower())
+    x = Sym("x", Upper())
+    y = Sym("y", Lower())
 
-    op1 = MD.BinaryOperation{*}(x, δ)
-    op2 = MD.BinaryOperation{*}(δ, x)
-
-    @test MD.get_free_indices(op1) == [Lower(1); Lower(1)]
-    @test MD.get_free_indices(op2) == [Lower(1); Lower(1)]
-end
-
-@testset "get_free_indices with Sym-Sym and no matching pairs" begin
-    x = Sym("x", Upper(1))
-    A = Sym("A", Upper(1), Lower(2))
-
-    op1 = MD.BinaryOperation{*}(x, A)
-    op2 = MD.BinaryOperation{*}(A, x)
-
-    @test MD.get_free_indices(op1) == [Upper(1); Upper(1); Lower(2)]
-    @test MD.get_free_indices(op2) == [Upper(1); Lower(2); Upper(1)]
-end
-
-@testset "is_contraction_unambigous vector-vector with matching pair" begin
-    x = Sym("x", Upper(1))
-    y = Sym("y", Lower(1))
-
-    @test MD.is_contraction_unambigous(x, y)
-    @test MD.is_contraction_unambigous(y, x)
-end
-
-@testset "is_contraction_unambigous vector-vector with non-matching pair" begin
-    x = Sym("x", Lower(1))
-    y = Sym("y", Lower(1))
-
-    @test !MD.is_contraction_unambigous(x, y)
-    @test !MD.is_contraction_unambigous(y, x)
-end
-
-@testset "is_contraction_unambigous matrix-vector with matching pair" begin
-    x = Sym("x", Upper(2))
-    A = Sym("A", Upper(1), Lower(2))
-
-    @test MD.is_contraction_unambigous(A, x)
-    @test MD.is_contraction_unambigous(x, A)
-end
-
-@testset "is_contraction_unambigous matrix-vector with non-matching pair" begin
-    x = Sym("x", Lower(3))
-    A = Sym("A", Upper(1), Lower(2))
-
-    @test MD.is_contraction_unambigous(A, x)
-    @test MD.is_contraction_unambigous(x, A)
-end
-
-@testset "is_valid_standard_notation fails with invalid input" begin
-    A = Sym("A", Upper(1), Lower(2))
-    x = Sym("x", Upper(1))
-    y = Sym("y", Lower(2))
-
-    @test !MD.is_valid_standard_notation(A, x)
-    @test !MD.is_valid_standard_notation(x, A)
-    @test !MD.is_valid_standard_notation(A, y)
-    @test !MD.is_valid_standard_notation(y, A)
-end
-
-@testset "is_valid_standard_notation succeeds with valid input" begin
-    A = Sym("A", Upper(1), Lower(2))
-    x = Sym("x", Upper(2))
-    y = Sym("y", Lower(1))
-
-    @test MD.is_valid_standard_notation(A, x)
-    @test MD.is_valid_standard_notation(y, A)
+    @test !MD.is_valid_multiplication(x, A)
+    @test !MD.is_valid_multiplication(A, y)
 end
 
 @testset "create BinaryOperation with matching indices" begin
-    x = Sym("x", Upper(2))
-    y = Sym("y", Lower(1))
-    z = Sym("z")
-    A = Sym("A", Upper(1), Lower(2))
+    x = Sym("x", Upper())
+    y = Sym("y", Lower())
+    A = Sym("A", Upper(), Lower())
 
     @test typeof(A * x) == MD.BinaryOperation{*}
     @test typeof(y * A) == MD.BinaryOperation{*}
-    @test typeof(z * A) == MD.BinaryOperation{*}
-    @test typeof(A * z) == MD.BinaryOperation{*}
 end
 
-@testset "update_index column vector" begin
-    x = Sym("x", Upper(3))
+# @testset "create ***Operation with matrix-scalar" begin
+#     x = Sym("x", Upper())
+#     A = Sym("A", Upper(), Lower())
+#     z = Sym("z")
 
-    @test MD.update_index(x, Upper(3), Upper(3)) == x
-
-    expected_shift = KrD(Lower(3), Upper(1))
-    @test MD.update_index(x, Upper(3), Upper(1)) == MD.BinaryOperation{*}(x, expected_shift)
-
-    expected_shift = KrD(Lower(3), Upper(2))
-    @test MD.update_index(x, Upper(3), Upper(2)) == MD.BinaryOperation{*}(x, expected_shift)
-
-    # update_index shall not transpose
-    @test_throws DomainError MD.update_index(x, Upper(3), Lower(1))
-end
-
-@testset "update_index row vector" begin
-    x = Sym("x", Lower(3))
-
-    @test MD.update_index(x, Lower(3), Lower(3)) == x
-
-    expected_shift = KrD(Upper(3), Lower(1))
-    @test MD.update_index(x, Lower(3), Lower(1)) == MD.BinaryOperation{*}(x, expected_shift)
-
-    expected_shift = KrD(Upper(3), Lower(2))
-    @test MD.update_index(x, Lower(3), Lower(2)) == MD.BinaryOperation{*}(x, expected_shift)
-
-    # update_index shall not transpose
-    @test_throws DomainError MD.update_index(x, Lower(3), Upper(1))
-end
-
-@testset "update_index matrix" begin
-    A = Sym("A", Upper(1), Lower(2))
-
-    @test MD.update_index(A, Lower(2), Lower(2)) == A
-
-    expected_shift = KrD(Upper(2), Lower(3))
-    @test MD.update_index(A, Lower(2), Lower(3)) == MD.BinaryOperation{*}(A, expected_shift)
-
-    # update_index shall not transpose
-    @test_throws DomainError MD.update_index(A, Lower(2), Upper(3))
-end
+#     @test typeof(A * x) == MD.BinaryOperation{*}
+#     @test typeof(y * A) == MD.BinaryOperation{*}
+#     @test typeof(z * A) == MD.BinaryOperation{*}
+#     @test typeof(A * z) == MD.BinaryOperation{*}
+# end
 
 @testset "transpose vector" begin
-    x = Sym("x", Upper(1))
-    y = Sym("y", Lower(1))
+    x = Sym("x", Upper())
+    y = Sym("y", Lower())
 
-    expected_shift = KrD(Lower(1), Lower(1))
-    @test x' == MD.BinaryOperation{*}(x, expected_shift)
+    expected_shift = KrD(Lower(), Lower())
+    @test x' == MD.BinaryOperation{*}(x, expected_shift, [(1, 1)])
 
-    expected_shift = KrD(Upper(1), Upper(1))
-    @test y' == MD.BinaryOperation{*}(y, expected_shift, )
-end
-
-@testset "combined update_index and transpose vector" begin
-    x = Sym("x", Upper(2))
-
-    updated_transpose = MD.update_index(x', Lower(2), Lower(1))
-
-    expected_first_shift = KrD(Lower(2), Lower(2))
-    expected_second_shift = KrD(Upper(2), Lower(1))
-    @test typeof(updated_transpose) == MD.BinaryOperation{*}
-    @test updated_transpose.arg2 == expected_second_shift
-    @test typeof(updated_transpose.arg1) == MD.BinaryOperation{*}
-    @test updated_transpose.arg1.arg1 == x
-    @test updated_transpose.arg1.arg2 == expected_first_shift
+    expected_shift = KrD(Upper(), Upper())
+    @test y' == MD.BinaryOperation{*}(y, expected_shift, [(1, 1)])
 end
 
 @testset "transpose matrix" begin
-    A = Sym("A", Upper(1), Lower(2))
+    A = Sym("A", Upper(), Lower())
 
-    expected_first_shift = KrD(Upper(2), Upper(2))
-    expected_second_shift = KrD(Lower(1), Lower(1))
+    expected_first_shift = KrD(Upper(), Upper())
+    expected_second_shift = KrD(Lower(), Lower())
     A_transpose = A'
     @test typeof(A_transpose) == MD.BinaryOperation{*}
     @test A_transpose.arg2 == expected_second_shift
@@ -311,74 +211,72 @@ end
 end
 
 @testset "can_contract" begin
-    A = Sym("A", Upper(1), Lower(2))
-    x = Sym("x", Upper(2))
-    y = Sym("y", Upper(3))
-    z = Sym("z", Lower(1))
-    d = KrD(Lower(1), Lower(1))
+    A = Sym("A", Upper(), Lower())
+    x = Sym("x", Upper())
+    y = Sym("y", Upper())
+    z = Sym("z", Lower())
+    d = KrD(Lower(), Lower())
 
-    @test MD.can_contract(A, x)
-    @test MD.can_contract(x, A)
-    @test !MD.can_contract(A, y)
-    @test !MD.can_contract(y, A)
-    @test MD.can_contract(A, d)
-    @test MD.can_contract(d, A)
-    @test MD.can_contract(A, z)
-    @test MD.can_contract(z, A)
+    @test MD.can_contract(A, x, [(2, 1)])
+    @test MD.can_contract(x, A, [(1, 2)])
+    @test !MD.can_contract(A, y, [(1, 1)])
+    @test !MD.can_contract(y, A, [(1, 1)])
+    @test MD.can_contract(A, d, [(1, 1)])
+    @test MD.can_contract(d, A, [(1, 1)])
+    @test MD.can_contract(A, z, [(1, 1)])
+    @test MD.can_contract(z, A, [(1, 1)])
 end
 
 @testset "create BinaryOperation with non-matching indices matrix-vector" begin
-    x = Sym("x", Upper(3))
-    A = Sym("A", Upper(1), Lower(2))
+    x = Sym("x", Upper())
+    A = Sym("A", Upper(), Lower())
 
     op1 = A * x
 
     @test typeof(op1) == MD.BinaryOperation{*}
-    @test MD.can_contract(op1.arg1, op1.arg2)
-    @test typeof(op1.arg1) == MD.BinaryOperation{*}
+    @test MD.can_contract(op1.arg1, op1.arg2, op1.indices)
+    @test op1.arg1 == A
     @test op1.arg2 == x
 
     op2 = x' * A
 
     @test typeof(op2) == MD.BinaryOperation{*}
-    @test MD.can_contract(op2.arg1, op2.arg2)
+    @test MD.can_contract(op2.arg1, op2.arg2, op2.indices)
     @test typeof(op2.arg1) == MD.BinaryOperation{*}
-    @test typeof(op2.arg1.arg1) == MD.BinaryOperation{*}
-    @test op2.arg1.arg1.arg1 == x
-    @test op2.arg1.arg1.arg2 == KrD(Lower(3), Lower(3))
-    @test op2.arg1.arg2 == KrD(Upper(3), Lower(1))
+    @test op2.arg1.arg1 == x
+    @test op2.arg1.arg2 == KrD(Lower(), Lower())
     @test op2.arg2 == A
 end
 
 @testset "create BinaryOperation with non-compatible matrix-vector fails" begin
-    x = Sym("x", Upper(3))
-    A = Sym("A", Upper(1), Lower(2))
+    x = Sym("x", Upper())
+    A = Sym("A", Upper(), Lower())
 
     @test_throws DomainError x * A
 end
 
 @testset "create BinaryOperation with non-matching indices vector-vector" begin
-    x = Sym("x", Upper(2))
-    y = Sym("y", Upper(1))
+    x = Sym("x", Upper())
+    y = Sym("y", Upper())
 
     op1 = x' * y
 
     @test typeof(op1) == MD.BinaryOperation{*}
-    @test MD.can_contract(op1.arg1, op1.arg2)
+    @test MD.can_contract(op1.arg1, op1.arg2, op1.indices)
     @test typeof(op1.arg1) == MD.BinaryOperation{*}
     @test op1.arg2 == y
 
     op2 = y' * x
 
     @test typeof(op2) == MD.BinaryOperation{*}
-    @test MD.can_contract(op2.arg1, op2.arg2)
+    @test MD.can_contract(op2.arg1, op2.arg2, op2.indices)
     @test typeof(op2.arg1) == MD.BinaryOperation{*}
     @test op2.arg2 == x
 end
 
 # TODO: Scalars not implemented
 # @testset "create BinaryOperation with non-matching indices scalar-matrix" begin
-#     A = Sym("A", Upper(1), Lower(2))
+#     A = Sym("A", Upper(), Lower())
 #     z = Sym("z")
 
 #     op1 = A * z
@@ -398,7 +296,7 @@ end
 # end
 
 # @testset "create BinaryOperation with non-matching indices scalar-vector" begin
-#     x = Sym("x", Upper(3))
+#     x = Sym("x", Upper())
 #     z = Sym("z")
 
 #     op1 = z * x


### PR DESCRIPTION
Moves letters out from Upper/Lower indices into the contraction operation.

+ Reduces code complexity and simplifies equality comparison of expressions.
- Makes correct printing more complicated.