### PR TITLE
Fix incorrect one-arg Base.hash method

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -42,14 +42,11 @@ function same_to(old::Upper, letter::Letter)
     return Upper(letter)
 end
 
-function hash(arg::LowerOrUpperIndex)
-    h::UInt = 0
-
+function hash(arg::LowerOrUpperIndex, h::UInt)
+    val::UInt = 0
     if typeof(arg) == Lower
-        h |= 1
+        val |= 1
     end
-
-    h |= arg.letter << 1
-
-    h
+    val |= arg.letter << 1
+    hash(val, h)
 end


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

## Summary

The `hash(arg::LowerOrUpperIndex)` method in `src/index.jl` only defines a one-arg `Base.hash`. This means the two-arg fallback `hash(x, h::UInt)` uses `objectid`-based hashing instead, which can cause:

- **Correctness bugs**: equal objects may hash differently when used in containers like `Dict` or `Set`
- **Performance issues**: excessive method invalidation across the ecosystem
- **Julia 1.13+ breakage**: the default hash seed is changing from `zero(UInt)` to a random value, so the one-arg method will produce different results each session

## Fix

Convert to a proper two-arg `hash(arg::LowerOrUpperIndex, h::UInt)` that chains the seed through the computation.

## Test plan

- Verified the fix compiles and the hash contract is maintained

---
This PR was generated with the assistance of generative AI.

Co-Authored-By: Claude <noreply@anthropic.com>